### PR TITLE
Escape braces in tapback AppleScript f-string

### DIFF
--- a/reply.py
+++ b/reply.py
@@ -547,7 +547,7 @@ def tapback_via_messages(chat_guid: str, message_guid: str, emoji: str, timeout:
       tell application "System Events"
         if not (exists process "Messages") then error "Messages is not running"
         tell process "Messages"
-          keystroke "t" using {command down}
+          keystroke "t" using {{command down}}
           delay 0.05
           keystroke "{reaction_key}"
         end tell


### PR DESCRIPTION
## Summary
- Fix SyntaxError in AppleScript tapback function by escaping braces in f-string

## Testing
- `pytest -q`
- `python -m py_compile reply.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5121daeec83248f4120d3bf918366