### PR TITLE
feat: support deleting conversations

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - **Mark resolved (until next inbound)** — press `z` to hide a thread that doesn’t need a reply; it will **re-appear automatically** when a new incoming message arrives. Use `u` to clear the marker.
 - **OpenAI draft (optional)** — send context + your notes to OpenAI to produce a short reply you can accept, edit, copy, or discard.
 - **Refresh without restarting** — press `R` to rebuild the list from the DB with current filters.
+- **Delete conversations** — press `d` to remove a thread from Messages after confirmation.
 - **Contact name resolution** — optionally pull names from the Contacts app.
 - **Custom aliases** — press `a` to associate your own name with a handle (phone/email). Aliases override Contacts and persist in the state file.
 - **Ignore state** — ignore a thread for N days or forever; clear later if needed.
@@ -171,9 +172,9 @@ s  skip (session) i  ignore Ndays     f      ignore forever
 z  mark resolved (until next inbound) u      unresolve (clear marker)
 r  reply (send/copy/both)            t      tapback reaction (pick #)
 g  LLM draft (accept/edit/copy/both) a      alias name (persist)
-o  open in Messages                  R      refresh threads from DB
-c  clear ignore on this thread       h      help
-q  quit (saves position & GUID; use --resume next time)
+o  open in Messages                  d      delete conversation
+R  refresh threads from DB           c      clear ignore on this thread
+h  help                              q      quit (saves position & GUID; use --resume next time)
 ```
 
 Notes:
@@ -184,6 +185,7 @@ Notes:
 - **Draft `g`** — add optional notes, then choose: `(a)ccept & send`, `(e)dit then send`, `(c)opy`, `(b)oth`, or `d`iscard.
 - **Alias `a`** — set a custom name for a participant handle (works in 1:1 and group chats). Aliases are immediate and persist.
 - **Refresh `R`** — rebuilds the list from the DB with your current filters; attempts to keep you on the same thread.
+- **Delete `d`** — remove the conversation from Messages after confirmation.
 - **Ignore `i` / `f`** — hide a thread for N days or forever (persisted). Use `c` to clear ignore later.
 - **Skip `s`** — session‑only; thread reappears on next run.
 


### PR DESCRIPTION
## Summary
- allow deleting a conversation via new `[d]elete` command in interactive mode
- add AppleScript helper `delete_chat` and document the command in help text and README

## Testing
- `python -m py_compile reply.py`
- `python reply.py -h`
- `python reply.py --help-full`

------
https://chatgpt.com/codex/tasks/task_e_68b50c039b708324be950b1cb3d6cd6f